### PR TITLE
Feature: replacing function with alias to support command output pipes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,10 +2,8 @@ sudo apt install -y xclip;
 
 zshrc="/home/$USER/.zshrc"
 bashrc="/home/$USER/.bashrc"
-copycat="copycat () {
-  cat \$1;
-  cat \$1 | xclip -selection clipboard;
-}"
+
+copycat="alias copycat='xclip -selection clipboard'"
 
 if [ -f $zshrc ]; then
     echo "zshrc exists.";


### PR DESCRIPTION
@Ahmed7fathi  Thank you for this helpful tool.

when we try to copy a commands output to the clipboard, the current functionality does not support it. it is because the `cat` command used by the `copycat` function does not redirect the output directly. it takes a file as an argument and not `stdin`.
by replacing the `function` with an `alias` it will handle both file and command output copying through linux command piping:
```bash
$ echo "HI" > test_file
$ copycat test_file
# copies the content of "test_file" into clipboard (e.g "HI")
$ echo "HI2" | copycat
# copies the output of the echo command to clipboard  (e.g "HI2")
```